### PR TITLE
Reset only passed sprites

### DIFF
--- a/modules/Render.js
+++ b/modules/Render.js
@@ -27,31 +27,10 @@ export default class Render
 
   }
 
-
-  clear ()
-  {
-    this.gfx.clear()
-
-    // Deactivate sprites outside of drawDistance
-    let baseSegment = this.scene.Segments.findSegment(this.scene.position)
-
-    this.scene.Segments.segments.forEach((segment) => {
-      if (segment.index < baseSegment.index ||
-          segment.index > baseSegment.index + this.drawDistance)
-      {
-        segment.sprites.forEach((sprite) => {
-          sprite.source.setActive(false)
-          sprite.source.setVisible(false)
-        })
-      }
-    })
-  }
-
-
   /**
    * Render all
    */
-  all ()
+  all (road)
   {
     let baseSegment           = this.scene.Segments.findSegment(this.scene.position),
         basePercent           = Util.percentRemaining(this.scene.position, this.scene.segmentLength),
@@ -71,6 +50,12 @@ export default class Render
         n, segment
         
     this.scene.playerY    = Util.interpolate(playerSegment.p1.world.y, playerSegment.p2.world.y, playerPercent)
+    this.gfx.clear()
+
+    // clear passed segments, could also calculate how many from last delta
+    let passed = 20, total = this.scene.Segments.segments.length;
+    for (n = 0; n < passed; n++)
+      road.setSprites((baseSegment.index - n - 1 + total) % total, false); // normalize index
     
     // Segment render loop (away from camera)
     for(n = 0 ; n < this.drawDistance ; n++) {

--- a/modules/Road.js
+++ b/modules/Road.js
@@ -18,7 +18,7 @@ export default class Road
 
   }
 
-  reset ()
+  reset (drawDistance)
   {
 
     this.scene.Segments.reset()
@@ -49,7 +49,7 @@ export default class Road
     this.scene.trackLength = this.scene.Segments.segments.length * this.scene.segmentLength
 
     console.log(this.scene.Segments.segments)
-
+    this.drawDistance = drawDistance
     this.resetSprites()
   }
 
@@ -110,13 +110,17 @@ export default class Road
 
     let randomFrame = manualFrames[Util.randomInt(0, manualFrames.length - 1)]
     // let randomFrame = this.frameNames[Util.randomInt(0, this.frameNames.length - 1)]
-    let item = this.scene.poolGroup.get(0, 0, sprite)
-    item.setFrame(randomFrame)
-    // item.setFrame('column')
+    let item = this.scene.poolGroup.create(0, 0, sprite, randomFrame, false, n < self.drawDistance)
     item.setOrigin(0, 0)
-		item.setVisible(false)
-		item.setActive(true)
     this.scene.Segments.segments[n].sprites.push({ source: item, offset: offset, scaleIn: 0.01 })
+  }
+
+  // would be ideal to move all segment operations to similar methods
+  setSprites(n, status) {
+    this.scene.Segments.segments[n].sprites.forEach((x) => {
+      x.source.setActive(status)
+      x.source.setVisible(status)
+    });
   }
 
   resetSprites ()

--- a/modules/Util.js
+++ b/modules/Util.js
@@ -14,14 +14,7 @@ const Util = {
   easeInOut:        function(a,b,percent)       { return a + (b-a)*((-Math.cos(percent*Math.PI)/2) + 0.5);        },
   exponentialFog:   function(distance, density) { return 1 / (Math.pow(Math.E, (distance * distance * density))); },
 
-  increase:  function(start, increment, max) { // with looping
-    var result = start + increment;
-    while (result >= max)
-      result -= max;
-    while (result < 0)
-      result += max;
-    return result;
-  },
+  increase:  function(start, increment, max) { return (start + increment + max) % max; },
 
   project: function(p, cameraX, cameraY, cameraZ, cameraDepth, width, height, roadWidth) {
     p.camera.x     = (p.world.x || 0) - cameraX

--- a/scenes/Game.js
+++ b/scenes/Game.js
@@ -172,13 +172,12 @@ export default class Game extends Phaser.Scene
       .setOrigin(0, 0)
 
       
-    this.Road.reset()
+    this.Road.reset(this.Render.drawDistance)
     
   }
 
   update (time, delta)
   {
-
 
     if (this.autoDrive && this.overrideFaster)
     {
@@ -194,8 +193,7 @@ export default class Game extends Phaser.Scene
     }
 
     // game loop
-    this.Render.clear()
-    this.Render.all()
+    this.Render.all(this.Road)
     this.playerUpdate(delta / 1000)
 
     // temp for debug


### PR DESCRIPTION
Hey, thanks for sharing your project 🙌 

Seen the reset sprites vod - occured to me it would be enough to reset sprites in the segments passed since the last update, so just wanted to throw that idea here. Also tweaked to create the first sprites in `drawDistance` as active (otherwise nothing deactivates them until passed).

No pressure accepting the PR - just sharing the idea, totally fine to ignore or go with something different. Have fun!